### PR TITLE
Make class index loading async if we don't use legacy classes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,5 +2,7 @@ parameters:
   level: 9
   paths:
     - src
+    - tests
   bootstrapFiles:
     - vendor/autoload.php
+  checkMissingIterableValueType: false

--- a/src/PrestashopAutoload.php
+++ b/src/PrestashopAutoload.php
@@ -29,12 +29,16 @@ final class PrestashopAutoload
         $this->classLoader = new LegacyClassLoader($rootDirectory, $cacheDirectory);
         $this->autoload = new Autoloader($rootDirectory);
 
-        $cacheFile = $this->classLoader->getClassIndexFilepath();
-        if (is_file($cacheFile)) {
-            $this->autoload->setClassIndex($this->classLoader->loadClassCache());
-        } else {
-            $this->generateIndex();
-        }
+        $this->autoload->setInitializationCallBack(
+            function () {
+                $cacheFile = $this->classLoader->getClassIndexFilepath();
+                if (is_file($cacheFile)) {
+                    $this->autoload->setClassIndex($this->classLoader->loadClassCache());
+                } else {
+                    $this->generateIndex();
+                }
+            }
+        );
     }
 
     public function generateIndex(): void


### PR DESCRIPTION


| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | By default, the classIndex should be built before being passed to the autoloader. But if we don't use the autoloader, we still build it. Which can lead to performance issues.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |  no
| How to test?      | Unit tests





- [x] Add tests